### PR TITLE
Allow generic environment variable names for API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Designed to run via **GitHub Actions** every 10 minutes.
    - `CANVAS_API_TOKEN` — a valid Canvas API token
    - `NOTION_DATABASE_ID` — the 32-char database ID from the Notion URL
    - `NOTION_TOKEN` — your Notion integration token
+   - *Alternatively, generic names like `API_TOKEN`, `TOKEN`, `API_KEY`, or `DATABASE_ID` may also be used.*
 4. Push this repo to GitHub. The included workflow runs every **10 minutes**.
 
 ## Local test (optional)
@@ -43,6 +44,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 
+# Default names shown; other aliases like `API_TOKEN`, `TOKEN`, `API_KEY`, or `DATABASE_ID` also work.
 export CANVAS_API_BASE="https://<your>.instructure.com"
 export CANVAS_API_TOKEN="<canvas token>"
 export NOTION_DATABASE_ID="<db id>"

--- a/canvas_api.py
+++ b/canvas_api.py
@@ -1,13 +1,20 @@
 import os
 import requests
 from urllib.parse import urljoin
-from utils import retry
+from utils import retry, get_env
 
-BASE = os.environ.get("CANVAS_API_BASE", "").rstrip("/")
-TOKEN = os.environ.get("CANVAS_API_TOKEN", "")
+# Allow a variety of env var names so the script isn't tied to specific platforms
+BASE = get_env("CANVAS_API_BASE", "API_BASE", "BASE_URL").rstrip("/")
+TOKEN = get_env(
+    "CANVAS_API_TOKEN",
+    "CANVAS_TOKEN",
+    "API_TOKEN",
+    "TOKEN",
+    "API_KEY",
+)
 
 if not BASE or not TOKEN:
-    raise SystemExit("Missing CANVAS_API_BASE or CANVAS_API_TOKEN env vars.")
+    raise SystemExit("Missing Canvas API base URL or token environment variables.")
 
 HEADERS = {
     "Authorization": f"Bearer {TOKEN}",

--- a/notion_api.py
+++ b/notion_api.py
@@ -1,13 +1,14 @@
 import os
 from notion_client import Client
 from notion_client.errors import APIResponseError
-from utils import retry
+from utils import retry, get_env
 
-NOTION_TOKEN = os.environ.get("NOTION_TOKEN", "")
-DATABASE_ID = os.environ.get("NOTION_DATABASE_ID", "")
+# Support multiple env var names for flexibility across platforms
+NOTION_TOKEN = get_env("NOTION_TOKEN", "NOTION_API_KEY", "API_TOKEN", "TOKEN", "API_KEY")
+DATABASE_ID = get_env("NOTION_DATABASE_ID", "DATABASE_ID", "DB_ID", "NOTION_DB")
 
 if not NOTION_TOKEN or not DATABASE_ID:
-    raise SystemExit("Missing NOTION_TOKEN or NOTION_DATABASE_ID env vars.")
+    raise SystemExit("Missing Notion token or database ID environment variables.")
 
 client = Client(auth=NOTION_TOKEN)
 
@@ -86,8 +87,8 @@ def verify_access():
         msg = body.get("message", str(e))
         if code == "unauthorized":
             raise SystemExit(
-                "NOTION_TOKEN appears invalid or not usable in this workflow. "
-                "Confirm the repo secret is the exact token (starts with ntn_), no quotes/spaces."
+                "The provided Notion token appears invalid or unusable in this workflow. "
+                "Confirm the token is correct and contains no extra quotes or spaces."
             )
         if code in ("object_not_found",):
             raise SystemExit(

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import os
 import time
 from functools import wraps
 
@@ -16,3 +17,15 @@ def retry(exceptions=(Exception,), tries=3, delay=1.0, backoff=2.0):
             return fn(*args, **kwargs)
         return wrapper
     return decorator
+
+
+def get_env(*names, default=""):
+    """Return the first non-empty environment variable from *names*.
+
+    This allows callers to accept multiple possible env var names for tokens or IDs.
+    """
+    for n in names:
+        v = os.environ.get(n)
+        if v:
+            return v
+    return default


### PR DESCRIPTION
## Summary
- accept multiple env var names for Canvas and Notion tokens
- add helper to retrieve first available environment variable
- clarify README about generic secret names

## Testing
- `python -m py_compile canvas_api.py notion_api.py utils.py sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a530ddf9c0832bb9b1389cf62109e4