### PR TITLE
Use Notion date type for due dates

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -63,6 +63,8 @@ def format_props(assignment, course_name, teacher_names, existing_status=None):
 
     st = status_props(existing_status, submitted_at)
 
+    due_date = {"start": due_at.date().isoformat()} if due_at else None
+
     props = {
         "Assignment Name": {
             "title": [{"text": {"content": assignment.get("name", "Untitled Assignment")}}]
@@ -70,7 +72,7 @@ def format_props(assignment, course_name, teacher_names, existing_status=None):
         "Class": {"multi_select": [{"name": course_name}] if course_name else []},
         "Teacher": {"multi_select": [{"name": t} for t in (teacher_names or [])]},
         "Type": {"select": a_type},
-        "Due date": {"date": {"start": due_at.isoformat() if due_at else None}},
+        "Due date": {"date": due_date},
         "Priority": {"select": priority},
         "Status": {"status": st["status"]},
         "Done": {"checkbox": st["checkbox"]},


### PR DESCRIPTION
## Summary
- ensure due dates are sent as Notion calendar dates

## Testing
- `python -m py_compile canvas_api.py notion_api.py sync.py utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a532ba0218832bb8e4ffbf1186a6eb