### PR TITLE
Align Notion properties with new schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ Designed to run via **GitHub Actions** every 10 minutes.
 | Notion Property    | Type         | Notes |
 |--------------------|--------------|-------|
 | **Assignment Name**| Title        | Page title in Notion |
-| **Class**          | Checkbox     | Checked for class assignments |
-| **Teacher**        | Select       | Instructor (auto-added if missing) |
+| **Class**          | Select       | Course name (auto-added if missing) |
+| **Teacher**        | Text         | Instructor(s) |
 | **Type**           | Select       | One of: Assignment, Quiz, Test (auto-added) |
 | **Due date**       | Date         | Canvas due date (UTC) |
 | **Status**         | Select       | Not started / In Progress / Completed; auto-set to Completed if submitted |
 | **Done**           | Checkbox     | Mirrors Completed status |
 | **Canvas ID**      | Text         | Hidden helper for de-dup and updates |
+| **NA**             | Select       | Always set to “Jordan” (auto-added) |
 
 > Your database can show any subset of these columns. The names must match exactly.
 
 ## Setup
 
 1. Create a **Notion database** with the exact property names above.
-   - Add a **Status** select property with options such as:
-     - *Not started*, *In Progress*, *Completed* (case-insensitive match is OK).
+   - `Class`, `Type`, `Status`, and `NA` should be **Select** properties (missing options are auto-created).
 2. In Notion, share that database with an integration and copy **NOTION_TOKEN**.
 3. In **GitHub → Settings → Secrets and variables → Actions → Secrets**, add:
    - `CANVAS_API_BASE` — e.g. `https://youruniversity.instructure.com`

--- a/notion_api.py
+++ b/notion_api.py
@@ -1,4 +1,3 @@
-import os
 from notion_client import Client
 from notion_client.errors import APIResponseError
 from utils import retry, get_env
@@ -30,12 +29,16 @@ def query_by_canvas_id(canvas_id: int):
         }
     )
 
-def _ensure_select_options(prop_name, want_names, prop_kind="select"):
+def _ensure_select_options(prop_name, want_names):
+    """Ensure select or multi-select properties include required options.
+
+    If updating the database is not permitted (e.g. read-only access), the
+    function silently skips without raising.
     """
-    Ensure select properties have the needed options.
-    Adds any missing ones so tags (Teacher, Type, Status) never fail.
-    """
-    db = retrieve_db()
+    try:
+        db = retrieve_db()
+    except APIResponseError:
+        return
     prop = db["properties"].get(prop_name)
     if not prop or prop["type"] not in ("select", "multi_select"):
         return
@@ -44,23 +47,30 @@ def _ensure_select_options(prop_name, want_names, prop_kind="select"):
     if not missing:
         return
     new_opts = prop[prop["type"]]["options"] + [{"name": n} for n in missing]
-    client.databases.update(
-        **{
-            "database_id": DATABASE_ID,
-            "properties": {
-                prop_name: {prop["type"]: {"options": new_opts}}
-            },
-        }
-    )
+    try:
+        client.databases.update(
+            **{
+                "database_id": DATABASE_ID,
+                "properties": {
+                    prop_name: {prop["type"]: {"options": new_opts}}
+                },
+            }
+        )
+    except APIResponseError:
+        # Lack of permission to edit the DB should not abort the run
+        pass
 
 def ensure_taxonomy(
-    teacher_names=(),
+    class_names=(),
     type_names=("Assignment", "Quiz", "Test"),
     status_names=("Not started", "In Progress", "Completed"),
+    na_names=("Jordan",),
 ):
-    _ensure_select_options("Teacher", teacher_names, "select")
-    _ensure_select_options("Type", type_names, "select")
-    _ensure_select_options("Status", status_names, "select")
+    """Add any missing select options for Class/Type/Status/NA."""
+    _ensure_select_options("Class", class_names)
+    _ensure_select_options("Type", type_names)
+    _ensure_select_options("Status", status_names)
+    _ensure_select_options("NA", na_names)
 
 def upsert_page(canvas_id, props):
     """Create or update a page identified by Canvas ID (text)."""


### PR DESCRIPTION
## Summary
- treat Class and Status as select fields and Teacher as text
- auto-create select options for Class/Type/Status/NA and tolerate read-only DBs
- always set NA to "Jordan" and document updated property schema

## Testing
- `python -m py_compile canvas_api.py notion_api.py sync.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a54bd8175c832b9ec1862a3d6466a9