### PR TITLE
Align Notion properties with new schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Designed to run via **GitHub Actions** every 10 minutes.
 
 | Notion Property    | Type         | Notes |
 |--------------------|--------------|-------|
-| **Assignment Name**| Title        | Page title in Notion |
+| **Name**           | Title        | Page title in Notion |
+| **Assignment Name**| Text         | Duplicate of the page title |
 | **Class**          | Select       | Course name (auto-added if missing) |
-| **Teacher**        | Select       | Course instructor (auto-added if missing) |
+| **Teacher**        | Text         | Course instructor |
 | **Type**           | Select       | One of: Assignment, Quiz, Test (auto-added) |
 | **Due date**       | Date         | Canvas due date (UTC) |
-| **Status**         | Status       | Not started / In Progress / Completed; auto-set to Completed if submitted |
+| **Status**         | Select       | Not started / In Progress / Completed; auto-added if missing |
 | **Done**           | Checkbox     | Mirrors Completed status |
 | **Canvas ID**      | Text         | Hidden helper for de-dup and updates |
 | **NA**             | People       | Always set to user “Jordan” (see `JORDAN_ID` env var) |
@@ -25,8 +26,8 @@ Designed to run via **GitHub Actions** every 10 minutes.
 ## Setup
 
 1. Create a **Notion database** with the exact property names above.
-   - `Class`, `Teacher`, and `Type` should be **Select** properties (missing options are auto-created).
-   - `Status` must be a **Status** property.
+   - `Class`, `Type`, and `Status` should be **Select** properties (missing options are auto-created).
+   - `Teacher` should be a plain **Text** property.
    - `NA` should be a **People** property and will be set to the user whose ID is supplied via `JORDAN_ID`.
 2. In Notion, share that database with an integration and copy **NOTION_TOKEN**.
 3. In **GitHub → Settings → Secrets and variables → Actions → Secrets**, add:

--- a/README.md
+++ b/README.md
@@ -11,27 +11,30 @@ Designed to run via **GitHub Actions** every 10 minutes.
 | Notion Property    | Type         | Notes |
 |--------------------|--------------|-------|
 | **Assignment Name**| Title        | Page title in Notion |
-| **Class**          | Checkbox     | Checked for class assignments |
-| **Teacher**        | Select       | Instructor (auto-added if missing) |
+| **Class**          | Select       | Course name (auto-added if missing) |
+| **Teacher**        | Select       | Course instructor (auto-added if missing) |
 | **Type**           | Select       | One of: Assignment, Quiz, Test (auto-added) |
 | **Due date**       | Date         | Canvas due date (UTC) |
-| **Status**         | Select       | Not started / In Progress / Completed; auto-set to Completed if submitted |
+| **Status**         | Status       | Not started / In Progress / Completed; auto-set to Completed if submitted |
 | **Done**           | Checkbox     | Mirrors Completed status |
 | **Canvas ID**      | Text         | Hidden helper for de-dup and updates |
+| **NA**             | People       | Always set to user “Jordan” (see `JORDAN_ID` env var) |
 
 > Your database can show any subset of these columns. The names must match exactly.
 
 ## Setup
 
 1. Create a **Notion database** with the exact property names above.
-   - Add a **Status** select property with options such as:
-     - *Not started*, *In Progress*, *Completed* (case-insensitive match is OK).
+   - `Class`, `Teacher`, and `Type` should be **Select** properties (missing options are auto-created).
+   - `Status` must be a **Status** property.
+   - `NA` should be a **People** property and will be set to the user whose ID is supplied via `JORDAN_ID`.
 2. In Notion, share that database with an integration and copy **NOTION_TOKEN**.
 3. In **GitHub → Settings → Secrets and variables → Actions → Secrets**, add:
    - `CANVAS_API_BASE` — e.g. `https://youruniversity.instructure.com`
    - `CANVAS_API_TOKEN` — a valid Canvas API token
    - `NOTION_DATABASE_ID` — the 32-char database ID from the Notion URL
    - `NOTION_TOKEN` — your Notion integration token
+   - `JORDAN_ID` — (optional) Notion user ID for “Jordan” to populate the `NA` people field
    - *Alternatively, generic names like `API_TOKEN`, `TOKEN`, `API_KEY`, or `DATABASE_ID` may also be used.*
 4. Push this repo to GitHub. The included workflow runs every **10 minutes**.
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Designed to run via **GitHub Actions** every 10 minutes.
 | **Status**         | Status       | Not started / In Progress / Completed; auto-added if missing |
 | **Done**           | Checkbox     | Mirrors Completed status |
 | **Canvas ID**      | Text         | Hidden helper for de-dup and updates |
-| **NA**             | People       | Always set to user “Jordan” (see `JORDAN_ID` env var) |
-
 > Your database can show any subset of these columns. The names must match exactly.
 
 ## Setup
@@ -28,14 +26,12 @@ Designed to run via **GitHub Actions** every 10 minutes.
    - `Class` and `Type` should be **Select** properties (missing options are auto-created).
    - `Status` should be a **Status** property; any missing options are added if the integration has edit access.
    - `Teacher` is a simple **Text** property.
-   - `NA` should be a **People** property and will be set to the user whose ID is supplied via `JORDAN_ID`.
 2. In Notion, share that database with an integration and copy **NOTION_TOKEN**.
 3. In **GitHub → Settings → Secrets and variables → Actions → Secrets**, add:
    - `CANVAS_API_BASE` — e.g. `https://youruniversity.instructure.com`
    - `CANVAS_API_TOKEN` — a valid Canvas API token
    - `NOTION_DATABASE_ID` — the 32-char database ID from the Notion URL
    - `NOTION_TOKEN` — your Notion integration token
-   - `JORDAN_ID` — (optional) Notion user ID for “Jordan” to populate the `NA` people field
    - *Alternatively, generic names like `API_TOKEN`, `TOKEN`, `API_KEY`, or `DATABASE_ID` may also be used.*
 4. Push this repo to GitHub. The included workflow runs every **10 minutes**.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Designed to run via **GitHub Actions** every 10 minutes.
 
 ## What it does
 
-- For each active Canvas course, pulls assignments with a due date.
+- For each active Canvas course, pulls assignments with a due date within an eight-month window before and after the run.
 - Creates/updates a page in your Notion database with the following properties:
 
 | Notion Property    | Type         | Notes |

--- a/README.md
+++ b/README.md
@@ -10,22 +10,24 @@ Designed to run via **GitHub Actions** every 10 minutes.
 
 | Notion Property    | Type         | Notes |
 |--------------------|--------------|-------|
-| **Assignment Name**| Title        | Page title in Notion |
+| **Name**           | Title        | Page title in Notion (assignment name) |
+| **Assignment Name**| Text         | Copy of the Canvas assignment name |
 | **Class**          | Select       | Course name (auto-added if missing) |
-| **Teacher**        | Text         | Course instructor |
+| **Teacher**        | Text         | Course instructor(s) |
 | **Type**           | Select       | One of: Assignment, Quiz, Test (auto-added) |
 | **Due date**       | Date         | Canvas due date (UTC) |
-| **Status**         | Status       | Not started / In Progress / Completed; auto-added if missing |
+| **Status**         | Select       | Not started / In Progress / Completed (auto-added) |
 | **Done**           | Checkbox     | Mirrors Completed status |
 | **Canvas ID**      | Text         | Hidden helper for de-dup and updates |
+| **NA**             | People       | Always tagged with Jordan |
 > Your database can show any subset of these columns. The names must match exactly.
 
 ## Setup
 
 1. Create a **Notion database** with the exact property names above.
-   - `Class` and `Type` should be **Select** properties (missing options are auto-created).
-   - `Status` should be a **Status** property; any missing options are added if the integration has edit access.
+   - `Class`, `Type`, and `Status` should be **Select** properties (missing options are auto-created).
    - `Teacher` is a simple **Text** property.
+   - `NA` is a **People** property; the script tags it with the person ID provided via `JORDAN_ID`.
 2. In Notion, share that database with an integration and copy **NOTION_TOKEN**.
 3. In **GitHub → Settings → Secrets and variables → Actions → Secrets**, add:
    - `CANVAS_API_BASE` — e.g. `https://youruniversity.instructure.com`

--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ Designed to run via **GitHub Actions** every 10 minutes.
 
 | Notion Property    | Type         | Notes |
 |--------------------|--------------|-------|
-| **Name**           | Title        | Page title in Notion |
-| **Assignment Name**| Text         | Duplicate of the page title |
+| **Assignment Name**| Title        | Page title in Notion |
 | **Class**          | Select       | Course name (auto-added if missing) |
-| **Teacher**        | Select       | Course instructor (auto-added if missing) |
+| **Teacher**        | Text         | Course instructor |
 | **Type**           | Select       | One of: Assignment, Quiz, Test (auto-added) |
 | **Due date**       | Date         | Canvas due date (UTC) |
-| **Status**         | Select       | Not started / In Progress / Completed; auto-added if missing |
+| **Status**         | Status       | Not started / In Progress / Completed; auto-added if missing |
 | **Done**           | Checkbox     | Mirrors Completed status |
 | **Canvas ID**      | Text         | Hidden helper for de-dup and updates |
 | **NA**             | People       | Always set to user “Jordan” (see `JORDAN_ID` env var) |
@@ -26,7 +25,9 @@ Designed to run via **GitHub Actions** every 10 minutes.
 ## Setup
 
 1. Create a **Notion database** with the exact property names above.
-   - `Class`, `Teacher`, `Type`, and `Status` should be **Select** properties (missing options are auto-created).
+   - `Class` and `Type` should be **Select** properties (missing options are auto-created).
+   - `Status` should be a **Status** property; any missing options are added if the integration has edit access.
+   - `Teacher` is a simple **Text** property.
    - `NA` should be a **People** property and will be set to the user whose ID is supplied via `JORDAN_ID`.
 2. In Notion, share that database with an integration and copy **NOTION_TOKEN**.
 3. In **GitHub → Settings → Secrets and variables → Actions → Secrets**, add:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Designed to run via **GitHub Actions** every 10 minutes.
 | **Name**           | Title        | Page title in Notion |
 | **Assignment Name**| Text         | Duplicate of the page title |
 | **Class**          | Select       | Course name (auto-added if missing) |
-| **Teacher**        | Text         | Course instructor |
+| **Teacher**        | Select       | Course instructor (auto-added if missing) |
 | **Type**           | Select       | One of: Assignment, Quiz, Test (auto-added) |
 | **Due date**       | Date         | Canvas due date (UTC) |
 | **Status**         | Select       | Not started / In Progress / Completed; auto-added if missing |
@@ -26,8 +26,7 @@ Designed to run via **GitHub Actions** every 10 minutes.
 ## Setup
 
 1. Create a **Notion database** with the exact property names above.
-   - `Class`, `Type`, and `Status` should be **Select** properties (missing options are auto-created).
-   - `Teacher` should be a plain **Text** property.
+   - `Class`, `Teacher`, `Type`, and `Status` should be **Select** properties (missing options are auto-created).
    - `NA` should be a **People** property and will be set to the user whose ID is supplied via `JORDAN_ID`.
 2. In Notion, share that database with an integration and copy **NOTION_TOKEN**.
 3. In **GitHub → Settings → Secrets and variables → Actions → Secrets**, add:

--- a/notion_api.py
+++ b/notion_api.py
@@ -62,11 +62,13 @@ def _ensure_select_options(prop_name, want_names):
 
 def ensure_taxonomy(
     class_names=(),
+    teacher_names=(),
     type_names=("Assignment", "Quiz", "Test"),
     status_names=("Not started", "In Progress", "Completed"),
 ):
-    """Add any missing select options for Class/Type/Status."""
+    """Add any missing select options for Class/Teacher/Type/Status."""
     _ensure_select_options("Class", class_names)
+    _ensure_select_options("Teacher", teacher_names)
     _ensure_select_options("Type", type_names)
     _ensure_select_options("Status", status_names)
 

--- a/notion_api.py
+++ b/notion_api.py
@@ -62,13 +62,11 @@ def _ensure_select_options(prop_name, want_names):
 
 def ensure_taxonomy(
     class_names=(),
-    teacher_names=(),
     type_names=("Assignment", "Quiz", "Test"),
     status_names=("Not started", "In Progress", "Completed"),
 ):
-    """Add any missing select options for Class/Teacher/Type/Status."""
+    """Add any missing select options for Class/Type/Status."""
     _ensure_select_options("Class", class_names)
-    _ensure_select_options("Teacher", teacher_names)
     _ensure_select_options("Type", type_names)
     _ensure_select_options("Status", status_names)
 

--- a/sync.py
+++ b/sync.py
@@ -65,13 +65,7 @@ def format_props(assignment, class_name, teacher_names, existing_status=None):
             ]
         },
         "Class": {"select": {"name": class_name}} if class_name else None,
-        "Teacher": {
-            "rich_text": [
-                {"text": {"content": teacher_name}}
-            ]
-        }
-        if teacher_name
-        else None,
+        "Teacher": {"select": {"name": teacher_name}} if teacher_name else None,
         "Type": {"select": a_type},
         "Due date": {"date": due_date},
         "Status": {"select": {"name": st["name"]}},
@@ -97,15 +91,20 @@ def run():
     # Touch Canvas just to verify auth early (optional, keeps nice failures)
     _ = me_profile()
 
-    # Pull courses and build taxonomy sets (for Class/Type/Status options)
+    # Pull courses and build taxonomy sets (for Class/Teacher/Type/Status options)
     courses = list_courses()
     course_names = []
+    teacher_names = set()
     for c in courses:
         cname = c.get("course_code") or c.get("name")
         if cname:
             course_names.append(cname)
+        for t in c.get("teachers") or []:
+            disp = t.get("display_name") or t.get("short_name") or t.get("name")
+            if disp:
+                teacher_names.add(disp)
 
-    ensure_taxonomy(class_names=course_names)
+    ensure_taxonomy(class_names=course_names, teacher_names=teacher_names)
 
     for c in courses:
         cid = c.get("id")

--- a/sync.py
+++ b/sync.py
@@ -4,7 +4,6 @@ from dateutil.relativedelta import relativedelta
 
 from canvas_api import list_courses, list_assignments, me_profile
 from notion_api import ensure_taxonomy, upsert_page, verify_access
-from utils import get_env
 import re
 
 # ----- Helpers -----
@@ -33,9 +32,6 @@ def status_props(existing_status_name, submitted_at):
     label = (existing_status_name or "Not started")
     done = label.lower() == "completed"
     return {"name": label, "done": done}
-
-JORDAN_PERSON_ID = get_env("JORDAN_ID", "JORDAN_USER_ID", "NA_PERSON_ID", "NA_JORDAN_ID")
-
 
 def format_props(assignment, class_name, teacher_names, existing_status=None):
     due_at = parse_iso(assignment.get("due_at"))
@@ -74,11 +70,7 @@ def format_props(assignment, class_name, teacher_names, existing_status=None):
                 {"text": {"content": str(assignment.get("id", ""))}}
             ]
         },
-        "NA": {"people": [{"id": JORDAN_PERSON_ID}]},
     }
-    # Skip NA property if Jordan's ID isn't provided
-    if not JORDAN_PERSON_ID:
-        props.pop("NA")
     return {k: v for k, v in props.items() if v is not None}
 
 # ----- Main sync -----


### PR DESCRIPTION
## Summary
- treat Teacher as a select option and auto-create course instructor entries
- use Notion's Status property instead of a select
- populate NA people field with Jordan using `JORDAN_ID`

## Testing
- `python -m py_compile canvas_api.py notion_api.py sync.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a54bd8175c832b9ec1862a3d6466a9